### PR TITLE
フリマアプリのDB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Things you may want to cover:
 - has_many :products
 - has_many :trade_messages
 - has_many :trades
+- has_many :evaluations
 
 ## productsテーブル
 
@@ -88,7 +89,7 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |product_id|integer|foreign_key: true|
-|category|string|null: false|
+|category|string|null: false, index: true|
 
 ### Association
 - belongs_to :product
@@ -144,12 +145,13 @@ Things you may want to cover:
 |review|text|
 
 ### Association
+- belongs_to :user
 
 ## sizesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |product_id|integer|foerign_key: true|
-|size|string|null: false|
+|size|string|null: false, index: true|
 
 ### Association
 
@@ -157,6 +159,14 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |product_id|integer|foerign_key: true|
-|bland|string|null: false|
+|bland|string|null: false, index: true|
+
+### Association
+
+## credentialsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|uid|string|
+|provider|string|
 
 ### Association

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Things you may want to cover:
 
 * ...
 
-## Usersテーブル
+## usersテーブル
 
 |Column|Type|Options|
 |------|----|-------|
@@ -66,7 +66,7 @@ Things you may want to cover:
 
 ### Association
 - has_many :comments
-- has_many :categorys, through: :products-categorys
+- has_many :categories, through: :products-categories
 - belongs_to :user
 - has_many :trade_messages
 - has_many :likes
@@ -89,15 +89,15 @@ Things you may want to cover:
 
 ### Association
 
-## categorysテーブル
+## categoriesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |category|string|null: false, index: true|
 
 ### Association
-- has_many :products, through: :products-categorys
+- has_many :products, through: :products-categories
 
-## products-categorysテーブル
+## products-categorテーブル
 |Column|Type|Options|
 |------|----|-------|
 |product_id|integer|foreign_key: true|
@@ -139,7 +139,7 @@ Things you may want to cover:
 - belongs_to :user
 - belongs_to :product
 
-## merpaysテーブル
+## profitsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Things you may want to cover:
 - has_many :trade_messages
 - has_many :trades
 - has_many :evaluations
+- has_many :likes
 
 ## productsテーブル
 
@@ -55,6 +56,7 @@ Things you may want to cover:
 |------|----|-------|
 |product_name|string|null: false|
 |description|text|null: false|
+|brand_id|integer|foreign_key: true, index: true|
 |condition|string|null: false|
 |shipping_cost|string|null: false|
 |shipping_method|string|null: false|
@@ -64,9 +66,11 @@ Things you may want to cover:
 
 ### Association
 - has_many :comments
-- has_many :categorys
+- has_many :categorys, through: :products-categorys
 - belongs_to :user
 - has_many :trade_messages
+- has_many :likes
+- belongs_to :bland
 
 ## product_statusテーブル
 
@@ -88,11 +92,20 @@ Things you may want to cover:
 ## categorysテーブル
 |Column|Type|Options|
 |------|----|-------|
-|product_id|integer|foreign_key: true|
 |category|string|null: false, index: true|
 
 ### Association
+- has_many :products, through: :products-categorys
+
+## products-categorysテーブル
+|Column|Type|Options|
+|------|----|-------|
+|product_id|integer|foreign_key: true|
+|category_id|integer|foreign_key: true|
+
+### Association
 - belongs_to :product
+- belongs_to :category
 
 ## commentsテーブル
 |Column|Type|Options|
@@ -109,7 +122,7 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |buyer_id|integer|foreign_key: true|
-|seller_id|intefer|foreign_key: true|
+|seller_id|integer|foreign_key: true|
 |product_id|integer|foreign_key: true|
 
 ### Association
@@ -140,7 +153,7 @@ Things you may want to cover:
 |------|----|-------|
 |rate|integer|null: false|
 |buyer_id|integer|foreign_key: true|
-|seller_id|intefer|foreign_key: true|
+|seller_id|integer|foreign_key: true|
 |product_id|integer|foerign_key: true|
 |review|text|
 
@@ -151,17 +164,17 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |product_id|integer|foerign_key: true|
-|size|string|null: false, index: true|
+|size|string|null: false|
 
 ### Association
 
 ## blandsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|product_id|integer|foerign_key: true|
-|bland|string|null: false, index: true|
+|bland|string|null: false|
 
 ### Association
+- has_many :products
 
 ## credentialsテーブル
 |Column|Type|Options|
@@ -170,3 +183,13 @@ Things you may want to cover:
 |provider|string|
 
 ### Association
+
+## likesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|foreign_key: true|
+|product_id|integer|foreign_key: true|
+
+### Association
+- belongs_to :user
+- belongs_to :product

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Things you may want to cover:
 |lastname_kana|string|null: false|
 |birthday|integer|null: false|
 |postalcode|integer|null: false|
-|address_pref|string|null: false|
-|address_city|string|null: false|
+|prefecture|string|null: false|
+|city_name|string|null: false|
 |address_number|string|null: false|
 |building_name|string|
 |phone_number|integer|unique: true, null: false|
@@ -54,15 +54,16 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|product_name|string|null: false|
+|name|string|null: false|
 |description|text|null: false|
 |brand_id|integer|foreign_key: true, index: true|
-|condition|string|null: false|
+|condition|integer|null: false, default: 0, limit: 1|
 |shipping_cost|string|null: false|
 |shipping_method|string|null: false|
 |source_area|string|null: false|
 |shipping_days|string|null: false|
 |price|integer|null: false|
+|status|integer|null: false, default: 0, limit: 1|
 
 ### Association
 - has_many :comments
@@ -71,15 +72,6 @@ Things you may want to cover:
 - has_many :trade_messages
 - has_many :likes
 - belongs_to :bland
-
-## product_statusテーブル
-
-|Column|Type|Options|
-|------|----|-------|
-|product_id|integer|foreign_key: true|
-|status|integer|null: false|
-
-### Association
 
 ## imagesテーブル
 |Column|Type|Options|
@@ -97,7 +89,7 @@ Things you may want to cover:
 ### Association
 - has_many :products, through: :products-categories
 
-## products-categorテーブル
+## products_categoriesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |product_id|integer|foreign_key: true|
@@ -171,7 +163,7 @@ Things you may want to cover:
 ## blandsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|bland|string|null: false|
+|name|string|null: false|
 
 ### Association
 - has_many :products

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Things you may want to cover:
 - has_many :buyed_products, foreign_key: "buyer_id", class_name: "Product"
 - has_many :selling_products, -> { where("buyer_id is NULL") }, foreign_key: "seller_id", class_name: "Product"
 - has_many :sold_products, -> { where("buyer_id is not NULL") }, foreign_key: "seller_id", class_name: "Product"
+- has_many :credentials
 
 ## productsテーブル
 
@@ -71,12 +72,15 @@ Things you may want to cover:
 
 ### Association
 - has_many :comments
-- has_many :categories, through: :products-categories
+- has_many :categories, through: :product-categories
 - has_many :trade_messages
 - has_many :likes
 - belongs_to :bland
 - belongs_to :buyer, class_name: "User"
 - belongs_to :seller, class_name: "User"
+- has_many :images
+- belongs_to :sizey
+- has_many :evaluations
 
 ## imagesテーブル
 |Column|Type|Options|
@@ -85,6 +89,7 @@ Things you may want to cover:
 |image|string|null: false|
 
 ### Association
+- belongs_to :product
 
 ## categoriesテーブル
 |Column|Type|Options|
@@ -92,9 +97,9 @@ Things you may want to cover:
 |category|string|null: false, index: true|
 
 ### Association
-- has_many :products, through: :products-categories
+- has_many :products, through: :product-categories
 
-## products_categoriesテーブル
+## product_categoriesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |product_id|integer|foreign_key: true|
@@ -136,7 +141,9 @@ Things you may want to cover:
 |review|text|
 
 ### Association
-- belongs_to :user
+- belongs_to :buyer_id, class_name: "Product"
+- belongs_to :seller_id, class_name: "Product"
+- belongs_to :product
 
 ## sizesテーブル
 |Column|Type|Options|
@@ -145,6 +152,7 @@ Things you may want to cover:
 |size|string|null: false|
 
 ### Association
+- has_many :products
 
 ## blandsテーブル
 |Column|Type|Options|
@@ -161,6 +169,7 @@ Things you may want to cover:
 |provider|string|
 
 ### Association
+- belongs_to :user
 
 ## likesテーブル
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ Things you may want to cover:
 - has_many :comments
 - has_many :products
 - has_many :trade_messages
-- has_many :trades
 - has_many :evaluations
 - has_many :likes
+- has_many :buyed_products, foreign_key: "buyer_id", class_name: "Product"
+- has_many :selling_products, -> { where("buyer_id is NULL") }, foreign_key: "seller_id", class_name: "Product"
+- has_many :sold_products, -> { where("buyer_id is not NULL") }, foreign_key: "seller_id", class_name: "Product"
 
 ## productsテーブル
 
@@ -64,14 +66,17 @@ Things you may want to cover:
 |shipping_days|string|null: false|
 |price|integer|null: false|
 |status|integer|null: false, default: 0, limit: 1|
+|buyer_id|integer|foreign_key: true|
+|seller_id|integer|foreign_key: true|
 
 ### Association
 - has_many :comments
 - has_many :categories, through: :products-categories
-- belongs_to :user
 - has_many :trade_messages
 - has_many :likes
 - belongs_to :bland
+- belongs_to :buyer, class_name: "User"
+- belongs_to :seller, class_name: "User"
 
 ## imagesテーブル
 |Column|Type|Options|
@@ -110,16 +115,6 @@ Things you may want to cover:
 - belongs_to :user
 - belongs_to :product
 
-## tradesテーブル
-|Column|Type|Options|
-|------|----|-------|
-|buyer_id|integer|foreign_key: true|
-|seller_id|integer|foreign_key: true|
-|product_id|integer|foreign_key: true|
-
-### Association
-- belongs_to :user
-
 ## trade_messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
@@ -130,15 +125,6 @@ Things you may want to cover:
 ### Association
 - belongs_to :user
 - belongs_to :product
-
-## profitsテーブル
-|Column|Type|Options|
-|------|----|-------|
-|user_id|integer|foreign_key: true|
-|profit|integer|
-|point|integer|
-
-### Association
 
 ## evaluationsテーブル
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -22,3 +22,141 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## Usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|nickname|string|null: false|
+|firstname|string|null: false|
+|lastname|string|null: false|
+|firstname_kana|string|null: false|
+|lastname_kana|string|null: false|
+|birthday|integer|null: false|
+|postalcode|integer|null: false|
+|address_pref|string|null: false|
+|address_city|string|null: false|
+|address_number|string|null: false|
+|building_name|string|
+|phone_number|integer|unique: true, null: false|
+|user_image|string|
+|profile|text|
+
+### Association
+- has_many :comments
+- has_many :products
+- has_many :trade_messages
+- has_many :trades
+
+## productsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|product_name|string|null: false|
+|description|text|null: false|
+|condition|string|null: false|
+|shipping_cost|string|null: false|
+|shipping_method|string|null: false|
+|source_area|string|null: false|
+|shipping_days|string|null: false|
+|price|integer|null: false|
+
+### Association
+- has_many :comments
+- has_many :categorys
+- belongs_to :user
+- has_many :trade_messages
+
+## product_statusテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|product_id|integer|foreign_key: true|
+|status|integer|null: false|
+
+### Association
+
+## imagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|product_id|integer|foreign_key: true|
+|image|string|null: false|
+
+### Association
+
+## categorysテーブル
+|Column|Type|Options|
+|------|----|-------|
+|product_id|integer|foreign_key: true|
+|category|string|null: false|
+
+### Association
+- belongs_to :product
+
+## commentsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|product_id|integer|foreign_key: true|
+|user_id|integer|foreign_key: true|
+|comment|text|null: false|
+
+### Association
+- belongs_to :user
+- belongs_to :product
+
+## tradesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|buyer_id|integer|foreign_key: true|
+|seller_id|intefer|foreign_key: true|
+|product_id|integer|foreign_key: true|
+
+### Association
+- belongs_to :user
+
+## trade_messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|foerign_key: true|
+|message|text|null: false|
+|product_id|integer|foerign_key: true|
+
+### Association
+- belongs_to :user
+- belongs_to :product
+
+## merpaysテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|foreign_key: true|
+|profit|integer|
+|point|integer|
+
+### Association
+
+## evaluationsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|rate|integer|null: false|
+|buyer_id|integer|foreign_key: true|
+|seller_id|intefer|foreign_key: true|
+|product_id|integer|foerign_key: true|
+|review|text|
+
+### Association
+
+## sizesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|product_id|integer|foerign_key: true|
+|size|string|null: false|
+
+### Association
+
+## blandsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|product_id|integer|foerign_key: true|
+|bland|string|null: false|
+
+### Association


### PR DESCRIPTION
# 実装内容
フリマアプリのDB設計

## テーブルの説明
### ユーザー関係
ユーザーの登録情報を保存するためのusersテーブル
認証情報を保存しておくcredentialsテーブル
売り上げ金をカウントするためのprofitsテーブル

### 商品関係
商品情報を保存するためのproductsテーブル
商品画像を保存しておくimagesテーブル
商品の状態（出品中、取引中、購入済み）を表すためのproduct_statusテーブル
商品のカテゴリーを保存しておくcategoryテーブル
商品のブランドを保存しておくbrandsテーブル
商品のサイズを保存しておくsizesテーブル
商品のいいね！情報を保存しておくlikesテーブル
productsテーブルとcategoriesテーブルを紐づけるproducts-categoriesテーブル
商品について質問などをするためのコメントを保存しておくcommentsテーブル

### 取引関係
売買取引においての取引情報を保存しておくためのtradesテーブル
売買取引においてメッセージのやりとりをするためのtrade_messagesテーブル
取引後にユーザーを評価するためのevaluationsテーブル

### ER図のURL
https://drive.google.com/file/d/1qIhMviXOT_0tl3iydMAFGkeEI6YrZmK1/view?usp=sharing