### PR TITLE
Basic認証の追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,16 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth, if: :production?
+  protect_from_forgery with: :exception
+
+  private
+
+  def production?
+    Rails.env.production?
+  end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -60,3 +60,6 @@
 #     # password: "please use keys"
 #   }
 server '54.178.242.48', user: 'ec2-user', roles: %w{app db web}
+
+set :rails_env, "production"
+set :unicorn_rack_env, "production"


### PR DESCRIPTION
# WHAT
production.rbに本番環境でのみ、ベーシック認証するようにする。
application_controller.rbにベーシック認証のためのユーザー名とパスワードを設定。
それらは環境変数にしてvimに記載。

# WHY
本番環境以外では実装する理由がなく、手間がかかるため。
本番環境で、後悔してしまうと、著作権であったり色々と問題が発生するため。