### PR TITLE
自動デプロイでBasic認証を導入する

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -55,6 +55,13 @@ set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }
 set :unicorn_config_path, -> { "#{current_path}/config/unicorn.rb" }
 set :keep_releases, 5
 
+set :default_env, {
+  rbenv_root: "/usr/local/rbenv",
+  path: "/usr/local/rbenv/shims:/usr/local/rbenv/bin:$PATH",
+  BASIC_AUTH_USER: ENV["BASIC_AUTH_USER"],
+  BASIC_AUTH_PASSWORD: ENV["BASIC_AUTH_PASSWORD"]
+}
+
 after 'deploy:publishing', 'deploy:restart'
 namespace :deploy do
   task :restart do


### PR DESCRIPTION
# WHAT
deploy.rbに自動デプロイで環境変数を読み込むように記載

# WHY
自動デプロイでBasic認証をする際に必須の機能あるため。