### PR TITLE
sns-credentialsテーブルを追加

### DIFF
--- a/app/models/sns_credential.rb
+++ b/app/models/sns_credential.rb
@@ -1,0 +1,2 @@
+class SnsCredential < ApplicationRecord
+end

--- a/db/migrate/20190611052823_create_sns_credentials.rb
+++ b/db/migrate/20190611052823_create_sns_credentials.rb
@@ -1,0 +1,11 @@
+class CreateSnsCredentials < ActiveRecord::Migration[5.2]
+  def change
+    create_table :sns_credentials do |t|
+      t.string :uid
+      t.string :provider
+      t.integer :user_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_05_110314) do
+ActiveRecord::Schema.define(version: 2019_06_11_052823) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -91,6 +91,14 @@ ActiveRecord::Schema.define(version: 2019_06_05_110314) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["product_id"], name: "index_sizes_on_product_id"
+  end
+
+  create_table "sns_credentials", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "uid"
+    t.string "provider"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/factories/sns_credentials.rb
+++ b/spec/factories/sns_credentials.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :sns_credential do
+    uid { "MyString" }
+    provider { "MyString" }
+    user_id { 1 }
+  end
+end

--- a/spec/models/sns_credential_spec.rb
+++ b/spec/models/sns_credential_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SnsCredential, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
sns-credentialsテーブル追加
## チェックポイント
なし
## 概要
sns-credentialsテーブル追加
## 実装内容
sns-credentialsテーブル追加
uid・provider・user_idを作成
## 動作確認項目
なし
## レビュアーへのコメント（見て欲しいポイント、注意点など）
sns-credentialsテーブル追加のみ