### PR TITLE
Categoryテーブルのカラム変更

### DIFF
--- a/db/migrate/20190612100513_remove_ancestry_to_categories.rb
+++ b/db/migrate/20190612100513_remove_ancestry_to_categories.rb
@@ -1,0 +1,5 @@
+class RemoveAncestryToCategories < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :categories, :ancestry
+  end
+end

--- a/db/migrate/20190612100831_add_ancestry_to_categories.rb
+++ b/db/migrate/20190612100831_add_ancestry_to_categories.rb
@@ -1,0 +1,6 @@
+class AddAncestryToCategories < ActiveRecord::Migration[5.2]
+  def change
+    add_column :categories, :ancestry, :string
+    add_index :categories, :ancestry
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_12_100513) do
+ActiveRecord::Schema.define(version: 2019_06_12_100831) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -51,6 +51,8 @@ ActiveRecord::Schema.define(version: 2019_06_12_100513) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "ancestry"
+    t.index ["ancestry"], name: "index_categories_on_ancestry"
   end
 
   create_table "product_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_12_090504) do
+ActiveRecord::Schema.define(version: 2019_06_12_100513) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -49,7 +49,6 @@ ActiveRecord::Schema.define(version: 2019_06_12_090504) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
-    t.integer "ancestry"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION

## 概要

categoryテーブルのancestryカラムがinteger型で作成されていたため、
string型で再度作成し直しました。

