### PR TITLE
Fix: 出品時にカテゴリーidが正しく保存されるよう修正

### DIFF
--- a/app/assets/javascripts/products_new.js
+++ b/app/assets/javascripts/products_new.js
@@ -2,7 +2,7 @@ $(function() {
 
 
   function appendSelect() {
-        var html = `<select class=“subcategory-form” name=“product[category_id]“ id = "select_id">
+        var html = `<select class=“subcategory-form” id = "select_id">
                       <option value=“”>---</option>
                     </select>`
 
@@ -10,7 +10,7 @@ $(function() {
   }
 
   function appendChildSelect() {
-    var html = `<select class=“subcategory-form” name=“product[category_id]“ id = "child_id">
+    var html = `<select class=“subcategory-form” name=product[category_id] id = "child_id">
                   <option value=“”>---</option>
                 </select>`
 
@@ -20,7 +20,8 @@ $(function() {
   $("#product_category_id").change(function(e) {
     e.preventDefault();
     $("#select_id, #child_id").remove();
-    var category_id = $(this).val();
+    var category_id = $("#product_category_id option:selected").attr("id");
+    debugger
     $.ajax({
       url: "/products/search",
       type: "GET",

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -36,7 +36,10 @@
               %label
                 カテゴリー
                 %span 必須
-              = f.collection_select :category_id, @parent, :id, :name, {prompt: "---"}, class: "category-form"
+              %select#product_category_id{:class => "“subcategory-form”",selected: @product.category_id}
+                %option ---
+                - @parent.each do |category|
+                  %option{ id: category.id}= category.name
             .sell-form__detail__select-box__size
               %label
                 サイズ


### PR DESCRIPTION
## 概要

- 修正前
   出品した際カテゴリーidとして保存されるのは、
   親カテゴリーのidとなっていた。

   例：レディース=>　パンツ　=>　デニムス
　　とカテゴリーを選んだ場合、保存されるのは"レディース"

- 修正後

   孫カテゴリーのカテゴリーidが保存されるように修正しました。

   例：レディース=>　パンツ　=>　デニムス
　　   とカテゴリーを選んだ場合、保存されるのは"デニムス"
  
## 修正理由

 - 孫カテゴリーが保存されることで、商品詳細のカテゴリー欄に、
    上記例のレディース=>　パンツ　=>　デニムスといった
    三階層のカテゴリ全てを表示することができるから。


 - 商品一覧ページで、各カテゴリごとの商品を表示するには、
    孫カテゴリーが保存される必要があったから。

