### PR TITLE
商品詳細画面の修正

### DIFF
--- a/app/assets/stylesheets/modules/products_show.scss
+++ b/app/assets/stylesheets/modules/products_show.scss
@@ -81,6 +81,7 @@ html, body {
                 border-right: 0px;
                 border-bottom: 0px;
                 width: 11em;
+                text-align: left;
               }
             }
           }

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -123,11 +123,12 @@
         - if product.id == @product.id
         - else
           .product-other-contents__box
-            %figure
-              - if product.images.attached?
-                - product.images.each_with_index do |image, i|
-                  - if i == 0
-                    = image_tag image, class:"photo photo-#{i}"
+            = link_to(product_path(product)) do
+              %figure
+                - if product.images.attached?
+                  - product.images.each_with_index do |image, i|
+                    - if i == 0
+                      = image_tag image, class:"photo photo-#{i}"
             %h2
               = product.name
             .price-box

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -26,6 +26,12 @@
             %td
               - if @product.category.present?
                 .name
+                = @product.category.root.name
+                .name
+                >
+                = @product.category.parent.name
+                .name
+                >
                 = @product.category.name
           %tr
             %th ブランド


### PR DESCRIPTION
## 概要

商品詳細ページの修正を行った。

## 実装内容

 - 商品詳細ページのカテゴリー欄で、
　親、子、孫カテゴリー全てが表示できるようにした。
 - カテゴリーが同一の商品にアクセスできるようリンクを貼った。
