### PR TITLE
Fix: カテゴリー選択ボックスで親カテゴリーを選択できるよう修正

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,7 +3,7 @@ class ProductsController < ApplicationController
 
   def new
     @product = Product.new
-    @parent = Category.order("id ASC").limit(1000)
+    @parent = Category.order("id ASC").limit(13)
   end
 
   def index


### PR DESCRIPTION
## 概要

商品出品ページのカテゴリー選択ボックスで、
親カテゴリーが選択できるよう修正を行った。