### PR TITLE
プロフィール編集エラー解除

### DIFF
--- a/app/views/layouts/_l-side.html.haml
+++ b/app/views/layouts/_l-side.html.haml
@@ -70,7 +70,7 @@
     %h3.mypage-nav-head 設定
     %ul.mypage-nav__list
       %li
-        = link_to "profiles/id/edit", class: "mypage-nav-list-item" do
+        = link_to edit_profile_path(current_user), class: "mypage-nav-list-item" do
           プロフィール
           %i.fas.fa-chevron-right
       %li

--- a/app/views/layouts/_l-side.html.haml
+++ b/app/views/layouts/_l-side.html.haml
@@ -70,7 +70,7 @@
     %h3.mypage-nav-head 設定
     %ul.mypage-nav__list
       %li
-        = link_to "/users/id/profiles/id/edit/", class: "mypage-nav-list-item" do
+        = link_to "profiles/id/edit", class: "mypage-nav-list-item" do
           プロフィール
           %i.fas.fa-chevron-right
       %li

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -5,7 +5,7 @@
     %section.profile-main
       %h2.profile-head プロフィール
 
-      = form_with url: edit_user_profile_path, method: :get, local: true do |f|
+      = form_with url: edit_profile_path, method: :get, local: true do |f|
         = f.hidden_field :"__csrf_value", class: "input-area", value: "cb20626d90c758f32ae2223b26035374a231ef258cf505e5b443eead6d7e22d297f7067933d1fc71389d7ac8dd12e8e3c6fe1a86f11cdbfa5618d8e29a9f5b26a"
 
         .setting-profile-icon


### PR DESCRIPTION
## 概要
プロフィール編集を押してもエラーにならないようにした。
ルート記述の修正




