### PR TITLE
商品編集（画像編集）機能の修正

### DIFF
--- a/app/assets/javascripts/product-image.js
+++ b/app/assets/javascripts/product-image.js
@@ -1,4 +1,5 @@
 $(function(){
+  var images = [];
   $(".sell-form__image__upload").change(function(e) {
     var file = e.target.files[0];
     var reader = new FileReader();
@@ -13,7 +14,21 @@ $(function(){
       })
     });
     reader.readAsDataURL(file);
+    images.push(file);
+    if(images.length < 5){
+      
+      $("label").css({
+        'width': `calc(88% - (18% * ${images.length}))`
+      })
+    }
 
-    $("label").width(490);
+  });
+
+  //商品編集時の処理
+  $(".edit__btn").on('click', function(e) {
+    if(images.length == 0) {
+      e.preventDefault();
+      $("html,body").scrollTop(0);
+    }
   });
 });

--- a/app/assets/stylesheets/products_sell.scss
+++ b/app/assets/stylesheets/products_sell.scss
@@ -403,6 +403,15 @@
         border: solid 1px #EA3732;
         cursor: pointer;
       }
+      .edit__btn {
+        height: 50px;
+        width: 100%;
+        background-color: #EA3732;
+        margin-top: 40px;
+        color: #FFFFFF;
+        border: solid 1px #EA3732;
+        cursor: pointer;
+      }
     }
     &__back {
       display: block;

--- a/app/views/productitems/show.html.haml
+++ b/app/views/productitems/show.html.haml
@@ -76,7 +76,7 @@
     .destroy-main
       %h2.destroy-head
       .setting-destroy
-        = link_to "商品の編集", edit_product_path, method: :edit, class: "btn-edit-red"
+        = link_to "商品の編集", edit_product_path, method: :GET, class: "btn-edit-red"
         %p or
         = link_to "出品を一旦停止する", "", data: { confirm: "現在、対応処理が出来ませんません。"}, class: "btn-delete-gray"
         = link_to "この商品を削除する", product_path(@product), method: :delete, data: { confirm: "この商品を削除します。本当によろしいですか？"}, class: "btn-delete-gray"

--- a/app/views/productitems/show.html.haml
+++ b/app/views/productitems/show.html.haml
@@ -76,7 +76,7 @@
     .destroy-main
       %h2.destroy-head
       .setting-destroy
-        = link_to "商品の編集", product_path(@product), method: :edit, class: "btn-edit-red"
+        = link_to "商品の編集", edit_product_path, method: :edit, class: "btn-edit-red"
         %p or
         = link_to "出品を一旦停止する", "", data: { confirm: "現在、対応処理が出来ませんません。"}, class: "btn-delete-gray"
         = link_to "この商品を削除する", product_path(@product), method: :delete, data: { confirm: "この商品を削除します。本当によろしいですか？"}, class: "btn-delete-gray"

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -144,7 +144,7 @@
         %p またブランド品でシリアルナンバー等がある場合はご記載ください。偽ブランドの販売は犯罪であり処罰される可能性があります。
         %p また、出品をもちまして加盟店規約に同意したことになります。
         .sell-form__submit__button
-          = f.submit "変更する", class: "sell-form__submit__button__btn", type: "submit"
+          = f.submit "変更する", class: "edit__btn", type: "submit"
         = link_to "もどる", "/", class: "sell-form__submit__back"
 
       = render "sub-footer"


### PR DESCRIPTION
## 概要
画像がなくても変更できてしまうので、修正しました。

## 実装内容
画像が選択されていない状態の場合は、"変更する"ボタンを押せないように修正
![Screen Recording 2019-06-20 at 15 23 31 mov](https://user-images.githubusercontent.com/50039645/59826646-ad530f00-9371-11e9-9341-4d1cd342711a.gif)

