### PR TITLE
商品を購入した際にbuyer_id に値を代入

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -5,6 +5,8 @@ class PaymentsController < ApplicationController
 
   def show
     @product = Product.find(params[:id])
+    @product[:buyer_id] = current_user.id
+    @product.save
     card = Card.where(user_id: current_user.id).first
     if card.blank?
       redirect_to action: "purchase/show"

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -65,5 +65,5 @@ class ProductsController < ApplicationController
   def product_params
     params.require(:product).permit(:name, :description, :category_id, :condition, :size, :bland, :shipping_cost, :shipping_method, :source_area, :shipping_day, :status, :buyer_id, :price, images: []).merge(seller_id: current_user.id)
   end
-  
+
 end


### PR DESCRIPTION
# WHAT
商品を購入するpaymentコントローラのshowアクションに、buyer_idにcurrent_user.idの値を代入。
saveしないとdbに保存されないため、その下にsaveアクションを記述。

# WHY
current_user.idを代入することで、buyer_idに値が入っている場合、売り切れの画面を表示し、なんども購入できないようにするため。また誰が買ったものなのか把握できるようにするため。