### PR TITLE
Fix: 購入済の商品は、関連カテゴリーの商品に表示しないための記述を追加

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -29,7 +29,7 @@ class ProductsController < ApplicationController
 
   def show
     category_id = @product.category_id
-    @products = Category.find(category_id).products
+    @products = Category.find(category_id).products.reject{|e| e[:buyer_id] != nil}
   end
 
   def create


### PR DESCRIPTION
## 概要

商品詳細ページの関連カテゴリーの商品一覧で、
購入済の商品は表示されないようにする記述を追加した。